### PR TITLE
Waiting for fitnesse startup by polling connection

### DIFF
--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
@@ -92,8 +92,7 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     private boolean stopTestsOnIgnore;
 
     /**
-     * If true, the mojo will stop when it encountered an exception error
-     * message.
+     * If true, the mojo will stop when it encountered an exception error message.
      */
     @Parameter(property = "stopTestsOnException", defaultValue = "true")
     private boolean stopTestsOnException;
@@ -214,8 +213,10 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Start the fitnesse commander.
      *
-     * @throws MojoFailureException   - unable to create FitNesseCommander.
-     * @throws MojoExecutionException - unable to start commander.
+     * @throws MojoFailureException
+     *             - unable to create FitNesseCommander.
+     * @throws MojoExecutionException
+     *             - unable to start commander.
      */
     private void startCommander() throws MojoFailureException, MojoExecutionException {
         commander =
@@ -226,6 +227,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
         } catch (MafiaException me) {
             throw new MojoExecutionException(me.getMessage(), me);
         }
+        getLog().debug("Fitnesse output: " + commander.getOutput());
+        getLog().debug("Fitnesse error output: " + commander.getErrorOutput());
         if (commander.hasError()) {
             logErrorMessages(commander.getOutput(), commander.getErrorOutput());
             throw new MojoExecutionException("Could not start FitNesse");
@@ -236,7 +239,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Stop the fitnesse commander.
      *
-     * @throws MojoExecutionException - unable to stop fitnesse.
+     * @throws MojoExecutionException
+     *             - unable to stop fitnesse.
      */
     private void stopCommander() throws MojoExecutionException {
         try {
@@ -250,7 +254,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Clear the test result output directory.
      *
-     * @throws MojoFailureException - unable to delete output directory.
+     * @throws MojoFailureException
+     *             - unable to delete output directory.
      * @param directory
      */
     private void clearOutputDirectory(String directory) throws MojoFailureException {
@@ -264,9 +269,12 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Save the test summaries and write properties file with total test results.
      *
-     * @param testSummaries - the test summaries to save.
-     * @param runDate       - date the test was run.
-     * @throws MafiaException - unable to save test summaries.
+     * @param testSummaries
+     *            - the test summaries to save.
+     * @param runDate
+     *            - date the test was run.
+     * @throws MafiaException
+     *             - unable to save test summaries.
      */
     private void saveTestSummariesAndWriteProperties(final Map<String, MafiaTestSummary> testSummaries,
         final Date runDate) throws MafiaException {
@@ -301,8 +309,10 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Save the properties file with total test results to disk.
      *
-     * @param properties - properties object.
-     * @throws MafiaException - unable to save properties.
+     * @param properties
+     *            - properties object.
+     * @throws MafiaException
+     *             - unable to save properties.
      */
     private void saveProperties(final Properties properties) throws MafiaException {
         FileOutputStream outputStream;
@@ -330,7 +340,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     /**
      * Write test results to maven log.
      *
-     * @param testSummaries - test summaries to log.
+     * @param testSummaries
+     *            - test summaries to log.
      */
     private void printTestResults(final Map<String, MafiaTestSummary> testSummaries) {
         if (testSummaries != null) {

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseStarterMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseStarterMojo.java
@@ -2,6 +2,7 @@ package nl.sijpesteijn.testing.fitnesse.plugins;
 
 import nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseCommander;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -19,17 +20,19 @@ public class FitNesseStarterMojo extends AbstractStartFitNesseMojo {
     public final void execute() throws MojoExecutionException, MojoFailureException {
         getLog().debug(toString());
         final FitNesseCommander commander = new FitNesseCommander(getCommanderConfig(getJvmDependencies(),
-                getJvmArguments(),
-                getRetainDays(), getFitNessePort(), getFitNesseAuthenticateStart()));
+            getJvmArguments(),
+            getRetainDays(), getFitNessePort(), getFitNesseAuthenticateStart()));
         try {
             commander.start();
         } catch (MafiaException me) {
             throw new MojoExecutionException(me.getMessage(), me);
         }
+        getLog().debug("Fitnesse output: " + commander.getOutput());
+        getLog().debug("Fitnesse error output: " + commander.getErrorOutput());
         if (commander.hasError()) {
             logErrorMessages(commander.getOutput(), commander.getErrorOutput());
             throw new MojoExecutionException("Could not start FitNesse: (error output: " + commander.getErrorOutput()
-                    + ", output: " + commander.getOutput() + ")");
+                + ", output: " + commander.getOutput() + ")");
         } else {
             getLog().info("FitNesse start on: http://localhost:" + getFitNessePort());
         }
@@ -41,8 +44,8 @@ public class FitNesseStarterMojo extends AbstractStartFitNesseMojo {
     @Override
     public final String toString() {
         return super.toString()
-                + ", Retain days: " + getRetainDays() + ", JVM arguments: " + getJvmArguments()
-                + ", JVM dependencies: " + getJvmDependencies();
+            + ", Retain days: " + getRetainDays() + ", JVM arguments: " + getJvmArguments()
+            + ", JVM dependencies: " + getJvmDependencies();
     }
 
 }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
@@ -227,15 +227,16 @@ public class FitNesseCommander {
      * @return boolean
      */
     public final boolean hasError() {
-        if (inputMonitor.getBuffer().toString().trim().contains("Started...")
-            || errorMonitor.getBuffer().toString().trim().contains("Please be patient.")
-            || StringUtils
-                .isEmpty(errorMonitor.getBuffer().toString())
-            || inputMonitor
-                .getBuffer()
-                .toString()
-                .contains(
-                    "Bootstrapping FitNesse, the fully integrated standalone wiki and acceptance testing framework.")) {
+        String stdErr = errorMonitor.getBuffer().toString().trim();
+        if (stdErr.contains("SEVERE")) {
+            return true;
+        }
+        String stdOut = inputMonitor.getBuffer().toString().trim();
+        if (stdOut.contains("Started...")
+            || stdErr.contains("Please be patient.")
+            || StringUtils.isEmpty(stdErr)
+            || stdOut
+                .contains("Bootstrapping FitNesse, the fully integrated standalone wiki and acceptance testing framework.")) {
             return false;
         }
         return true;

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
@@ -1,10 +1,14 @@
 package nl.sijpesteijn.testing.fitnesse.plugins.runner;
 
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
-import org.apache.commons.lang.StringUtils;
-
 import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.util.List;
+
+import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * FitNesseCommander interface.
@@ -34,7 +38,8 @@ public class FitNesseCommander {
     /**
      * Constructor.
      *
-     * @param commanderConfig - The command configuration.
+     * @param commanderConfig
+     *            - The command configuration.
      */
     public FitNesseCommander(final FitNesseCommanderConfig commanderConfig) {
         this.commanderConfig = commanderConfig;
@@ -43,7 +48,8 @@ public class FitNesseCommander {
     /**
      * Start FitNesse.
      *
-     * @throws MafiaException thrown in case of an error.
+     * @throws MafiaException
+     *             thrown in case of an error.
      */
     public final void start() throws MafiaException {
         String logArgument = "";
@@ -52,57 +58,56 @@ public class FitNesseCommander {
         }
         String authArgumentStart = "";
         if (commanderConfig.getFitNesseAuthenticateStart() != null) {
-        	authArgumentStart = " -a " + commanderConfig.getFitNesseAuthenticateStart();
+            authArgumentStart = " -a " + commanderConfig.getFitNesseAuthenticateStart();
         }
-        
+
         String updatePreventsArgument = "";
         if (commanderConfig.getFitNesseUpdatePrevents() != null && commanderConfig.getFitNesseUpdatePrevents()) {
-        	updatePreventsArgument = " -o";
+            updatePreventsArgument = " -o";
         }
         String verboseArgument = "";
         if (commanderConfig.getFitNesseVerbose() != null && commanderConfig.getFitNesseVerbose()) {
-        	verboseArgument = " -v";
+            verboseArgument = " -v";
         }
-        
+
         final String command = "java" + getJVMArguments(commanderConfig.getJvmArguments())
-                + " -cp " + commanderConfig.getClasspathString()
-                + " fitnesseMain.FitNesseMain -p " + commanderConfig.getFitNessePort()
-                + " -d " + commanderConfig.getWikiRoot()
-                + " -r " + commanderConfig.getNameRootPage()
-                + " -e " + commanderConfig.getRetainDays()
-                + logArgument
-                + authArgumentStart
-                + updatePreventsArgument
-                + verboseArgument;
-        
+            + " -cp " + commanderConfig.getClasspathString()
+            + " fitnesseMain.FitNesseMain -p " + commanderConfig.getFitNessePort()
+            + " -d " + commanderConfig.getWikiRoot()
+            + " -r " + commanderConfig.getNameRootPage()
+            + " -e " + commanderConfig.getRetainDays()
+            + logArgument
+            + authArgumentStart
+            + updatePreventsArgument
+            + verboseArgument;
+
         commanderConfig.getLog().info("Starting FitNesse. This could take some more seconds when first used....");
-       
 
         this.commanderConfig.getLog().debug("Starting FitNesse with Command:" + command);
-        
+
         run(command);
     }
 
     /**
      * Stop FitNesse.
      *
-     * @throws MafiaException thrown in case of an error.
+     * @throws MafiaException
+     *             thrown in case of an error.
      */
     public final void stop() throws MafiaException {
-    	
+
         String authArgument = "";
-        if (commanderConfig.getFitNesseAuthenticateStop() != null 
-          // in Shutdown fitnesse does not support user/paassword reading from file
-          // so we detect a valid user:password with the ":" separator
-          && commanderConfig.getFitNesseAuthenticateStop().contains(":")) {
-        	String userPasswordArgument = commanderConfig.getFitNesseAuthenticateStop().replaceFirst(":", " ");
-        	authArgument = " -c " + userPasswordArgument;
+        if (commanderConfig.getFitNesseAuthenticateStop() != null
+            // in Shutdown fitnesse does not support user/paassword reading from file
+            // so we detect a valid user:password with the ":" separator
+            && commanderConfig.getFitNesseAuthenticateStop().contains(":")) {
+            String userPasswordArgument = commanderConfig.getFitNesseAuthenticateStop().replaceFirst(":", " ");
+            authArgument = " -c " + userPasswordArgument;
         }
-    	
 
         final String command = "java -cp " + commanderConfig.getClasspathString() + " fitnesse.Shutdown -p "
-                + commanderConfig.getFitNessePort()
-                + authArgument;
+            + commanderConfig.getFitNessePort()
+            + authArgument;
 
         this.commanderConfig.getLog().debug("Stopping FitNesse with Command:" + command);
         run(command);
@@ -111,52 +116,73 @@ public class FitNesseCommander {
     /**
      * Run the command.
      *
-     * @param command - command.
-     * @throws MafiaException - unable to execute command.
+     * @param command
+     *            - command.
+     * @throws MafiaException
+     *             - unable to execute command.
      */
     private void run(final String command) throws MafiaException {
         try {
             commanderConfig.getLog().debug("Running command: " + command);
             process = Runtime.getRuntime().exec(command, null, new File(commanderConfig.getWikiRoot()));
-            errorMonitor = new StreamToBufferMonitor(process.getErrorStream());
-            new Thread(errorMonitor).start();
-            inputMonitor = new StreamToBufferMonitor(process.getInputStream());
-            new Thread(inputMonitor).start();
-            waitForProcess();
+            try {
+                boolean isStartUp = command.contains("fitnesseMain.FitNesseMain");
+                if (isStartUp) {
+                    waitForFitnesseStartup();
+                }
+            } catch (MafiaException e) {
+                throw e;
+            } finally {
+                errorMonitor = new StreamToBufferMonitor(process.getErrorStream());
+                errorMonitor.run();
+                inputMonitor = new StreamToBufferMonitor(process.getInputStream());
+                inputMonitor.run();
+            }
         } catch (Exception e) {
             throw new MafiaException("Could not run command.", e);
         }
     }
 
-    /**
-     * Wait for process.
-     *
-     * @throws InterruptedException - unable to check process status.
-     */
-    @SuppressWarnings("PMD")
-    private void waitForProcess() throws InterruptedException {
-        while (true) {
+    private void waitForFitnesseStartup() throws MafiaException {
+        String fitnesseUrl = "http://localhost:" + commanderConfig.getFitNessePort() + "/";
+        commanderConfig.getLog().debug(
+            "Polling URL " + fitnesseUrl + " in order to see when Fitnesse has finished startup.");
+        sleep(2000);
+        int maxTries = 4;
+        for (int i = 1; i <= maxTries; i++) {
             try {
-                process.exitValue();
+                tryConnect(fitnesseUrl);
+                commanderConfig.getLog().info("Fitnesse started.");
                 return;
-            } catch (IllegalThreadStateException itse) {
-                // process has not finished yet.
+            } catch (IOException e) {
+                commanderConfig.getLog().debug(
+                    "Couldn't connect to fitnesse: " + e.getMessage() + ". Waiting and then retry... (Try " + i + "/"
+                        + maxTries + ")");
+                sleep(3000);
             }
-            if (inputMonitor.isFinished()) {
-                if (errorMonitor.getBuffer().toString().trim()
-                        .endsWith("Unpacking new version of FitNesse resources. Please be patient.")) {
-                    Thread.sleep(commanderConfig.getUnpackWaitTime());
-                }
-                return;
-            }
-            Thread.sleep(commanderConfig.getUnpackWaitTime());
         }
+        throw new MafiaException("Couldn't connect to fitnesse server.");
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e1) {
+            throw new RuntimeException("Thread couldn't sleep.");
+        }
+    }
+
+    private void tryConnect(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        HttpURLConnection urlConn = (HttpURLConnection) url.openConnection();
+        urlConn.connect();
     }
 
     /**
      * Get jvm arguments.
      *
-     * @param arguments - jvm arguments.
+     * @param arguments
+     *            - jvm arguments.
      * @return - jvm argument string.
      */
     private String getJVMArguments(final List<String> arguments) {
@@ -202,9 +228,14 @@ public class FitNesseCommander {
      */
     public final boolean hasError() {
         if (inputMonitor.getBuffer().toString().trim().contains("Started...")
-                || errorMonitor.getBuffer().toString().trim().contains("Please be patient.") || StringUtils
+            || errorMonitor.getBuffer().toString().trim().contains("Please be patient.")
+            || StringUtils
                 .isEmpty(errorMonitor.getBuffer().toString())
-                || inputMonitor.getBuffer().toString().contains("Bootstrapping FitNesse, the fully integrated standalone wiki and acceptance testing framework.")) {
+            || inputMonitor
+                .getBuffer()
+                .toString()
+                .contains(
+                    "Bootstrapping FitNesse, the fully integrated standalone wiki and acceptance testing framework.")) {
             return false;
         }
         return true;

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/StreamToBufferMonitor.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/StreamToBufferMonitor.java
@@ -25,7 +25,8 @@ public class StreamToBufferMonitor implements Runnable {
     /**
      * Constructor.
      *
-     * @param inputStream {@link java.io.InputStream}
+     * @param inputStream
+     *            {@link java.io.InputStream}
      */
     public StreamToBufferMonitor(final InputStream inputStream) {
         this.inputStream = inputStream;

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/StreamToBufferMonitor.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/StreamToBufferMonitor.java
@@ -39,6 +39,9 @@ public class StreamToBufferMonitor implements Runnable {
     @SuppressWarnings("PMD")
     public final void run() {
         try {
+            if (inputStream.available() <= 0) {
+                return;
+            }
             int c = inputStream.read();
             while (c != -1 && inputStream.available() > 0) {
                 buffer.append((char) c);

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
@@ -24,87 +24,90 @@ import org.xml.sax.SAXException;
  */
 public class TestResultReader {
 
-	private Log log;
+    private Log log;
 
-	public TestResultReader(Log log) {
-		this.log = log;
-	}
+    public TestResultReader(Log log) {
+        this.log = log;
+    }
 
-	public List<TestResult> readAllTestResultFiles(File baseFolder) {
-		List<File> testResultFiles = getLatestTestResultFiles(baseFolder);
-		List<TestResult> testResults = new ArrayList<TestResult>(testResultFiles.size());
-		for (File testResultFile : testResultFiles) {
-			try {
-				TestResult testResult = readTestResultFile(testResultFile);
-				boolean isValidTestResults = testResult != null;
-				if (isValidTestResults) {
-					testResults.add(testResult);
-				}
-			} catch (TestResultException ex) {
-				log.error(ex.getMessage());
-				log.debug(ex);
-			}
-		}
-		return testResults;
-	}
+    public List<TestResult> readAllTestResultFiles(File baseFolder) {
+        List<File> testResultFiles = getLatestTestResultFiles(baseFolder);
+        List<TestResult> testResults = new ArrayList<TestResult>(testResultFiles.size());
+        for (File testResultFile : testResultFiles) {
+            try {
+                TestResult testResult = readTestResultFile(testResultFile);
+                boolean isValidTestResults = testResult != null;
+                if (isValidTestResults) {
+                    testResults.add(testResult);
+                }
+            } catch (TestResultException ex) {
+                log.error(ex.getMessage());
+                log.debug(ex);
+            }
+        }
+        return testResults;
+    }
 
-	private List<File> getLatestTestResultFiles(File baseFolder) {
-		File[] testFolders = baseFolder.listFiles();
-		List<File> result = new ArrayList<File>(testFolders.length);
-		for (File testFolder : testFolders) {
-			result.add(getLatestTestResultFile(testFolder));
-		}
-		return result;
-	}
+    private List<File> getLatestTestResultFiles(File baseFolder) {
+        File[] testFolders = baseFolder.listFiles();
+        List<File> result = new ArrayList<File>(testFolders.length);
+        for (File testFolder : testFolders) {
+            result.add(getLatestTestResultFile(testFolder));
+        }
+        return result;
+    }
 
-	File getLatestTestResultFile(File testFolder) {
-		File[] listFiles = testFolder.listFiles();
-		Arrays.sort(listFiles);
-		File file = listFiles[listFiles.length - 1];
-		return file;
-	}
+    File getLatestTestResultFile(File testFolder) {
+        File[] listFiles = testFolder.listFiles();
+        Arrays.sort(listFiles);
+        File file = listFiles[listFiles.length - 1];
+        return file;
+    }
 
-	TestResult readTestResultFile(File testResultFile) throws TestResultException {
-		try {
-			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-			Document document = builder.parse(testResultFile);
-			Element rootElement = document.getDocumentElement();
-			if (!rootElement.getNodeName().equals("testResults")) {
-				return null;
-			}
+    TestResult readTestResultFile(File testResultFile) throws TestResultException {
+        try {
+            DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            Document document = builder.parse(testResultFile);
+            Element rootElement = document.getDocumentElement();
+            if (!rootElement.getNodeName().equals("testResults")) {
+                return null;
+            }
 
-			XPath xpath = XPathFactory.newInstance().newXPath();
-			Element countsNode = (Element) xpath.evaluate("result/counts", rootElement, XPathConstants.NODE);
-			String rightCount = countsNode.getElementsByTagName("right").item(0).getTextContent();
-			String wrongCount = countsNode.getElementsByTagName("wrong").item(0).getTextContent();
-			String ignoresCount = countsNode.getElementsByTagName("ignores").item(0).getTextContent();
-			String exceptionsCount = countsNode.getElementsByTagName("exceptions").item(0).getTextContent();
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            Element countsNode = (Element) xpath.evaluate("result/counts", rootElement, XPathConstants.NODE);
+            String rightCount = countsNode.getElementsByTagName("right").item(0).getTextContent();
+            String wrongCount = countsNode.getElementsByTagName("wrong").item(0).getTextContent();
+            String ignoresCount = countsNode.getElementsByTagName("ignores").item(0).getTextContent();
+            String exceptionsCount = countsNode.getElementsByTagName("exceptions").item(0).getTextContent();
 
-			String runTimeString = (String) xpath.evaluate("result/runTimeInMillis/text()", rootElement,
-				XPathConstants.STRING);
+            String runTimeString = (String) xpath.evaluate("result/runTimeInMillis/text()", rootElement,
+                XPathConstants.STRING);
 
-			String path = (String) xpath.evaluate("rootPath", rootElement, XPathConstants.STRING);
+            String path = (String) xpath.evaluate("rootPath", rootElement, XPathConstants.STRING);
 
-			TestResult testResult = new TestResult()
-				.withPath(path)
-				.withRightTestCount(Integer.parseInt(rightCount))
-				.withWrongTestCount(Integer.parseInt(wrongCount))
-				.withIgnoredTestCount(Integer.parseInt(ignoresCount))
-				.withExceptionCount(Integer.parseInt(exceptionsCount))
-				.withRunTimeInMillis(Long.parseLong(runTimeString));
-			return testResult;
-		} catch (ParserConfigurationException e) {
-			throw fireException(testResultFile, e);
-		} catch (SAXException e) {
-			throw fireException(testResultFile, e);
-		} catch (IOException e) {
-			throw fireException(testResultFile, e);
-		} catch (XPathExpressionException e) {
-			throw fireException(testResultFile, e);
-		}
-	}
+            TestResult testResult = new TestResult()
+                .withPath(path)
+                .withRightTestCount(Integer.parseInt(rightCount))
+                .withWrongTestCount(Integer.parseInt(wrongCount))
+                .withIgnoredTestCount(Integer.parseInt(ignoresCount))
+                .withExceptionCount(Integer.parseInt(exceptionsCount))
+                .withRunTimeInMillis(Long.parseLong(runTimeString));
+            return testResult;
+        } catch (NullPointerException e) {
+            log.error("NullPointerException while trying to read XML. Node not found. file: " + testResultFile);
+            return null;
+        } catch (ParserConfigurationException e) {
+            throw fireException(testResultFile, e);
+        } catch (SAXException e) {
+            throw fireException(testResultFile, e);
+        } catch (IOException e) {
+            throw fireException(testResultFile, e);
+        } catch (XPathExpressionException e) {
+            throw fireException(testResultFile, e);
+        }
+    }
 
-	private TestResultException fireException(File testResultFile, Exception e) {
-		throw new TestResultException("Couldn't create TestResult from file " + testResultFile, e);
-	}
+    private TestResultException fireException(File testResultFile, Exception e) {
+        throw new TestResultException("Couldn't create TestResult from file " + testResultFile, e);
+    }
 }


### PR DESCRIPTION
Hi Gijs,

Use case: On our Jenkins we have several Jobs running in parallel causing a high load on the Jenkins machine. In this cases mafia:test determines with an Connection Refused Exception when he tries to execute the first test. The reason is, that FitNesse has not finished startup due to the high load.
The current waiting approach is to analyze the stdout and stderr of the FitNesse process, which is fragile. Moreover, separate threads are used to read the stdout and stderr and they are only read once. What happens if the StreamToBufferMonitors reads the stream, but FitNesse has not finished started? We get only a fragment of the output (i had this case often).

Therefore, I like to contribute an improvement. I propose a polling mechanism for waiting for the startup of FitNesse. The FitNesse process is started and after that I try to open a connection to the FitNesse server. If the connection is refused I wait and retry. If the connection could be established successfully, we can be pretty sure, that the server is running and our tests can run. I think that this approach is straight-forward and reliable.

I'm looking forward to your response
Kind Regards
Philipp