### PR TITLE
Fixed appearance of generated mafia results html document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - openjdk6
+  - openjdk7

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,15 @@
             </roles>
             <timezone>+1</timezone>
         </developer>
+        <developer>
+            <id>phauer</id>
+            <name>Philipp Hauer</name>
+            <url>http://blog.philipphauer.de</url>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+            <timezone>+1</timezone>
+        </developer>
     </developers>
 
     <issueManagement>
@@ -49,6 +58,8 @@
     </scm>
 
     <properties>
+    	<java.version>1.7</java.version>
+    
         <project.build.sourceEndcoding>UTF-8</project.build.sourceEndcoding>
         <fitnesse.version>20140630</fitnesse.version>
         <maven.version>3.0.5</maven.version>
@@ -78,8 +89,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
@@ -17,7 +17,9 @@ import nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseTestRunner;
 import nl.sijpesteijn.testing.fitnesse.plugins.runner.ResultStore;
 import nl.sijpesteijn.testing.fitnesse.plugins.runner.TestCaller;
 import nl.sijpesteijn.testing.fitnesse.plugins.runner.URLTestCaller;
+import nl.sijpesteijn.testing.fitnesse.plugins.utils.FitNesseResourceAccess;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
+import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaRuntimeException;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.SurefireReportWriter;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.TestResult;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.TestResultReader;
@@ -162,6 +164,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
                 saveTestSummariesAndWriteProperties(runner.getTestSummaries(), startDate);
                 printTestResults(runner.getTestSummaries());
                 getLog().info("Finished test run.");
+                copyFitNesseResourcesTo(outputDirectory
+                    + FitNesseResourceAccess.RESOURCES_FOLDER_NAME_WITHIN_MAFIARESULTS);
                 writeSurefireReportsIfNecessary();
             } catch (MafiaException e) {
                 throw new MojoFailureException("Failed to run tests.", e);
@@ -172,6 +176,16 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
             }
         } else {
             getLog().info("Skipping mafia reporting.");
+        }
+    }
+
+    private void copyFitNesseResourcesTo(String targetResourceDir) throws MojoFailureException {
+        getLog().debug("Copying the fitnesse resources (css, js etc.) to " + targetResourceDir + " ...");
+        FitNesseResourceAccess fitNesseJarAccess = new FitNesseResourceAccess(getMafiaProject());
+        try {
+            fitNesseJarAccess.copyResourcesTo(targetResourceDir);
+        } catch (MafiaRuntimeException e) {
+            getLog().warn("Couldn't copy resources (css, js) to " + targetResourceDir, e);
         }
     }
 

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
@@ -201,7 +201,8 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
             String buildDirectory = mavenProject.getBuild().getDirectory();
             File surefireReportBaseDir = new File(buildDirectory, "/surefire-reports/");
             surefireReportBaseDir.mkdirs();
-            SurefireReportWriter surefireReportWriter = new SurefireReportWriter(getLog(), outputDirectory);
+            SurefireReportWriter surefireReportWriter = new SurefireReportWriter(getLog(), outputDirectory,
+                testResultsFolder);
             surefireReportWriter.serialize(allTestResultFiles, surefireReportBaseDir);
         }
     }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/DiskResultStore.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/DiskResultStore.java
@@ -1,9 +1,16 @@
 package nl.sijpesteijn.testing.fitnesse.plugins.runner;
 
-import nl.sijpesteijn.testing.fitnesse.plugins.report.MafiaTestSummary;
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
+import static java.text.MessageFormat.*;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+
+import nl.sijpesteijn.testing.fitnesse.plugins.report.MafiaTestSummary;
+import nl.sijpesteijn.testing.fitnesse.plugins.utils.FitNesseResourceAccess;
+import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
 
 /**
  * DiskResultStore.
@@ -16,7 +23,7 @@ public class DiskResultStore implements ResultStore {
      */
     @Override
     public final MafiaTestSummary saveResult(final String content, final File resultsDirectory,
-                                       final String fileName) throws MafiaException {
+        final String fileName) throws MafiaException {
         resultsDirectory.mkdirs();
         File resultFile = new File(resultsDirectory, fileName + ".html");
         MafiaTestSummary summary = null;
@@ -27,11 +34,11 @@ public class DiskResultStore implements ResultStore {
             for (int i = 0; i < lines.length; i++) {
                 String line = lines[i];
                 if (line.contains("getElementById(\"test-summary\")")
-                        && line.contains("<strong>Assertions:</strong>")) {
+                    && line.contains("<strong>Assertions:</strong>")) {
                     summary = updateSummary(line);
                 }
                 line = updatePaths(line);
-                writer.write(line);
+                writer.write(line + "\n");
             }
             writer.close();
             fos.close();
@@ -44,12 +51,14 @@ public class DiskResultStore implements ResultStore {
     /**
      * Update the paths.
      *
-     * @param line - html string.
+     * @param line
+     *            - html string.
      * @return - updated html.
      */
     private String updatePaths(final String line) {
         if (line.contains("/files/fitnesse/")) {
-            return line.replaceAll("/files/fitnesse/", "./");
+            return line.replaceAll("/files/fitnesse/",
+                format("../{0}/", FitNesseResourceAccess.RESOURCES_FOLDER_NAME_WITHIN_MAFIARESULTS));
         }
         return line;
     }
@@ -57,7 +66,8 @@ public class DiskResultStore implements ResultStore {
     /**
      * Update the mafia test summary with result.
      *
-     * @param inputLine - html result string.
+     * @param inputLine
+     *            - html result string.
      * @return - mafia test summary.
      */
     private MafiaTestSummary updateSummary(final String inputLine) {

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/FitNesseResourceAccess.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/FitNesseResourceAccess.java
@@ -1,0 +1,73 @@
+package nl.sijpesteijn.testing.fitnesse.plugins.utils;
+
+import static java.text.MessageFormat.*;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class FitNesseResourceAccess {
+
+    public static final String RESOURCES_FOLDER_NAME_WITHIN_MAFIARESULTS = "resources";
+    private static final String RESOURCES_PATH_WITHIN_FITNESSERJAR = "/fitnesse/resources";
+    private Project project;
+
+    public FitNesseResourceAccess(Project project) {
+        this.project = project;
+    }
+
+    public void copyResourcesTo(String targetResourceFolder) throws MafiaRuntimeException {
+        try {
+            FitNesseJarLocator locator = new FitNesseJarLocator(project);
+            String fitNesseJarPath = locator.getFitNesseJarPath();
+            Path resourcesPath = getResourcesPath(fitNesseJarPath);
+            copyResources(resourcesPath, targetResourceFolder);
+        } catch (MafiaException e) {
+            throw new MafiaRuntimeException(e);
+        }
+    }
+
+    private void copyResources(Path sourceResourcesPath, final String targetResourceFolder)
+        throws MafiaRuntimeException {
+        try {
+            Files.walkFileTree(sourceResourcesPath, new SimpleFileVisitor<Path>() {
+                public FileVisitResult visitFile(Path sourceResourceFile, BasicFileAttributes attrs) throws IOException {
+                    String subPathWithinResource = sourceResourceFile.toString().replace(
+                        RESOURCES_PATH_WITHIN_FITNESSERJAR, "");
+                    Path targetFile = Paths.get(targetResourceFolder, subPathWithinResource);
+                    Files.createDirectories(targetFile);
+                    Files.copy(sourceResourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            String message = format("Could copy resources (css, js) from {0} to {1}", sourceResourcesPath,
+                targetResourceFolder);
+            throw new MafiaRuntimeException(message, e);
+        }
+    }
+
+    private Path getResourcesPath(String fitnesseJarPathString) throws MafiaRuntimeException {
+        Path fitnesseJarPath = Paths.get(fitnesseJarPathString);
+        try {
+            FileSystem fitnesseJar = FileSystems.newFileSystem(fitnesseJarPath, null);
+            Path resources = fitnesseJar.getPath(RESOURCES_PATH_WITHIN_FITNESSERJAR);
+            if (!Files.exists(resources)) {
+                String message = format("Could not find folder {0} in jar {1}", RESOURCES_PATH_WITHIN_FITNESSERJAR,
+                    fitnesseJar);
+                throw new MafiaRuntimeException(message);
+            }
+            return resources;
+        } catch (IOException e) {
+            throw new MafiaRuntimeException("Could not access the fitnesse artifact " + fitnesseJarPathString, e);
+        }
+    }
+
+}

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/MafiaRuntimeException.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/MafiaRuntimeException.java
@@ -1,0 +1,34 @@
+package nl.sijpesteijn.testing.fitnesse.plugins.utils;
+
+/**
+ * MafiaException.
+ */
+@SuppressWarnings("serial")
+public class MafiaRuntimeException extends RuntimeException {
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     *            - the error message.
+     * @param throwable
+     *            - the exception
+     */
+    public MafiaRuntimeException(final String message, final Throwable throwable) {
+        super(message, throwable);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message
+     *            - the error message.
+     */
+    public MafiaRuntimeException(final String message) {
+        super(message);
+    }
+
+    public MafiaRuntimeException(Throwable e) {
+        super(e);
+    }
+}

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
@@ -17,9 +17,12 @@ public class SurefireReportWriter {
 
     private String mafiaResultsDir;
 
-    public SurefireReportWriter(Log log, String mafiaResultsDir) {
+    private String testResultsDir;
+
+    public SurefireReportWriter(Log log, String mafiaResultsDir, String testResultsDir) {
         this.log = log;
         this.mafiaResultsDir = mafiaResultsDir;
+        this.testResultsDir = testResultsDir;
     }
 
     final static String SUREFIRE_REPORT_TEMPLATE =
@@ -32,7 +35,8 @@ public class SurefireReportWriter {
 
     final static String SUREFIRE_REPORT_ERROR_PART_TEMPLATE =
         "<error type=\"java.lang.AssertionError\" message=\"exceptions: %s wrong: %s\"><br/>"
-            + "See %s in workspace for more details."
+            + "See %s in workspace for more details.<br/>"
+            + "See %s for the execution log."
             + "</error>";
 
     public void serialize(List<TestResult> testResults, File surefireReportBaseDir) {
@@ -82,7 +86,8 @@ public class SurefireReportWriter {
         String surefireReportContent = String.format(SUREFIRE_REPORT_ERROR_PART_TEMPLATE,
             testResult.getExceptionCount(),
             testResult.getWrongTestCount(),
-            mafiaResultsDir
+            mafiaResultsDir,
+            testResultsDir
             );
         return surefireReportContent;
     }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -30,7 +31,13 @@ public class TestResultReader {
         this.log = log;
     }
 
+    @SuppressWarnings("unchecked")
     public List<TestResult> readAllTestResultFiles(File baseFolder) {
+        if (!baseFolder.exists()) {
+            log.info("Could not read Test Results. Folder " + baseFolder
+                + " doesn't exist. Probably no tests have been executed.");
+            return Collections.EMPTY_LIST;
+        }
         List<File> testResultFiles = getLatestTestResultFiles(baseFolder);
         List<TestResult> testResults = new ArrayList<TestResult>(testResultFiles.size());
         for (File testResultFile : testResultFiles) {

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriterTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriterTest.java
@@ -10,9 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.SurefireReportWriter;
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.TestResult;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.junit.Before;
@@ -20,70 +17,70 @@ import org.junit.Test;
 
 public class SurefireReportWriterTest {
 
-	private SurefireReportWriter surefireReportWriter;
+    private SurefireReportWriter surefireReportWriter;
 
-	@Before
-	public void init() {
-		surefireReportWriter = new SurefireReportWriter(new SilentLog(), "dummypath/");
-	}
+    @Before
+    public void init() {
+        surefireReportWriter = new SurefireReportWriter(new SilentLog(), "dummypath/", "dummypath2/");
+    }
 
-	@Test
-	public void serializeManyFiles() throws FileNotFoundException, IOException {
-		List<TestResult> testResults = createDummyTestResults();
+    @Test
+    public void serializeManyFiles() throws FileNotFoundException, IOException {
+        List<TestResult> testResults = createDummyTestResults();
 
-		File surefireReportsFolder = new File("target/testResources/actual-surefire-reports2");
-		surefireReportsFolder.mkdirs();
+        File surefireReportsFolder = new File("target/testResources/actual-surefire-reports2");
+        surefireReportsFolder.mkdirs();
 
-		surefireReportWriter.serialize(testResults, surefireReportsFolder);
+        surefireReportWriter.serialize(testResults, surefireReportsFolder);
 
-		long fileCount = surefireReportsFolder.list().length;
-		assertEquals(2, fileCount);
+        long fileCount = surefireReportsFolder.list().length;
+        assertEquals(2, fileCount);
 
-		List<String> createdReportFiles = Arrays.asList(surefireReportsFolder.list());
-		assertTrue(createdReportFiles.contains("TEST-Suite1.Suite11.Test1.xml"));
-		assertTrue(createdReportFiles.contains("TEST-Suite2.Suite21.Test2.xml"));
-	}
+        List<String> createdReportFiles = Arrays.asList(surefireReportsFolder.list());
+        assertTrue(createdReportFiles.contains("TEST-Suite1.Suite11.Test1.xml"));
+        assertTrue(createdReportFiles.contains("TEST-Suite2.Suite21.Test2.xml"));
+    }
 
-	private List<TestResult> createDummyTestResults() {
-		TestResult expectedTestResult = new TestResult()
-			.withPath("Suite1.Suite11.Test1")
-			.withRightTestCount(5)
-			.withWrongTestCount(4)
-			.withIgnoredTestCount(1)
-			.withExceptionCount(1)
-			.withRunTimeInMillis(300);
-		TestResult expectedTestResult2 = new TestResult()
-			.withPath("Suite2.Suite21.Test2")
-			.withRightTestCount(3)
-			.withWrongTestCount(2)
-			.withIgnoredTestCount(2)
-			.withExceptionCount(5)
-			.withRunTimeInMillis(500);
-		List<TestResult> input = new ArrayList<TestResult>();
-		input.add(expectedTestResult);
-		input.add(expectedTestResult2);
-		return input;
-	}
+    private List<TestResult> createDummyTestResults() {
+        TestResult expectedTestResult = new TestResult()
+            .withPath("Suite1.Suite11.Test1")
+            .withRightTestCount(5)
+            .withWrongTestCount(4)
+            .withIgnoredTestCount(1)
+            .withExceptionCount(1)
+            .withRunTimeInMillis(300);
+        TestResult expectedTestResult2 = new TestResult()
+            .withPath("Suite2.Suite21.Test2")
+            .withRightTestCount(3)
+            .withWrongTestCount(2)
+            .withIgnoredTestCount(2)
+            .withExceptionCount(5)
+            .withRunTimeInMillis(500);
+        List<TestResult> input = new ArrayList<TestResult>();
+        input.add(expectedTestResult);
+        input.add(expectedTestResult2);
+        return input;
+    }
 
-	@Test
-	public void serializeSingleFile() throws FileNotFoundException, IOException {
-		TestResult expectedTestResult = new TestResult()
-			.withPath("Suite1.Suite11.Test1")
-			.withRightTestCount(5)
-			.withWrongTestCount(4)
-			.withIgnoredTestCount(1)
-			.withExceptionCount(1)
-			.withRunTimeInMillis(300);
+    @Test
+    public void serializeSingleFile() throws FileNotFoundException, IOException {
+        TestResult expectedTestResult = new TestResult()
+            .withPath("Suite1.Suite11.Test1")
+            .withRightTestCount(5)
+            .withWrongTestCount(4)
+            .withIgnoredTestCount(1)
+            .withExceptionCount(1)
+            .withRunTimeInMillis(300);
 
-		File serializedReportFolder = new File("target/testResources/actual-surefire-reports");
-		serializedReportFolder.mkdirs();
-		File serializedReport = new File("target/testResources/actual-surefire-reports/report1.xml");
-		surefireReportWriter.serialize(expectedTestResult, serializedReport);
+        File serializedReportFolder = new File("target/testResources/actual-surefire-reports");
+        serializedReportFolder.mkdirs();
+        File serializedReport = new File("target/testResources/actual-surefire-reports/report1.xml");
+        surefireReportWriter.serialize(expectedTestResult, serializedReport);
 
-		List<String> serializedReportContent = IOUtils.readLines(new FileReader(serializedReport));
-		File expectedReport = new File("src/test/resources/expected-surefire-reports/report1.xml");
-		List<String> expectedReportContent = IOUtils.readLines(new FileReader(expectedReport));
+        List<String> serializedReportContent = IOUtils.readLines(new FileReader(serializedReport));
+        File expectedReport = new File("src/test/resources/expected-surefire-reports/report1.xml");
+        List<String> expectedReportContent = IOUtils.readLines(new FileReader(expectedReport));
 
-		assertEquals(expectedReportContent, serializedReportContent);
-	}
+        assertEquals(expectedReportContent, serializedReportContent);
+    }
 }

--- a/src/test/resources/expected-surefire-reports/report1.xml
+++ b/src/test/resources/expected-surefire-reports/report1.xml
@@ -1,6 +1,6 @@
 <testsuite errors="1" skipped="1" tests="11" time="0.3" failures="4" name="Suite1.Suite11">
 <properties/>
 <testcase classname="Suite1.Suite11.Test1" time="0.3" name="Test1">
-<error type="java.lang.AssertionError" message="exceptions: 1 wrong: 4"><br/>See dummypath/ in workspace for more details.</error>
+<error type="java.lang.AssertionError" message="exceptions: 1 wrong: 4"><br/>See dummypath/ in workspace for more details.<br/>See dummypath2/ for the execution log.</error>
 </testcase>
 </testsuite>


### PR DESCRIPTION
Hi Gijs,

I like to propose another enhancement.
When I execute a test or a suite with mafia:test mafia generates an html file (with the evaluated test tables) under FitNesseRoot/files/mafiaResults. This is pretty nice, because it enables us to investigate failed tests on our CI server (jenkins). Unfortunately, the resources (css, js files) are missing. So it is hard to keep an overview or to quickly jump to a failed test.

I implemented a simple copy mechanism, that copies the resources (css, js) out of the fitnesse.jar to FitNesseRoot/files/mafiaResults/resources. Moreover, I fix the link paths in the html document, so they point to this resources.

Best Regards, Philipp