### PR TITLE
Maintenance: Small Enhancements and Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,6 @@ Configuration:
         <td>Classpath entries for the jvm.</td>
     </tr>
     <tr>
-        <td>unpackWaitTime</td>
-        <td>3000 milliseconds</td>
-        <td>Time to wait after unpacking a fitnesse.</td>
-    </tr>
-    <tr>
         <td>fitNesseAuthenticateStart</td>
         <td>no auth</td>
         <td>username:password - Enforces access for one user or /auth/file/path/and/name - Enforces access for a file of users with encrypted passwords</td>
@@ -109,7 +104,6 @@ Configuration example with defaults and example values:
 			&lt;wikiRoot&gt;${basedir}&lt;/wikiRoot&gt;
 			&lt;nameRootPage&gt;FitNesseRoot&lt;/nameRootPage&gt;
 			&lt;retainDays&gt;14&lt;/retainDays&gt;
-			&lt;unpackWaitTime&gt;3000&lt;/unpackWaitTime&gt;
 			&lt;jvmArguments&gt;
 				&lt;jvmArgument&gt;CM_SYSTEM=fitnesse.wiki.cmSystems.GitCmSystem&lt;/jvmArgument&gt;
 			&lt;/jvmArguments&gt;

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This plugin let's you control:
 
 Supported versions of FitNesse:
 
+- 20150424
 - 20150226
 - 20140630
 - 20140623

--- a/README.md
+++ b/README.md
@@ -266,11 +266,6 @@ Configuration:
         <td>tag filter to use. Used in combination with a suitePageName</td>
     </tr>
     <tr>
-        <td>unpackWaitTime</td>
-        <td>3000 milliseconds</td>
-        <td>Time to wait after unpacking a fitnesse.</td>
-    </tr>
-    <tr>
         <td>fitNesseAuthenticateStart</td>
         <td>no auth</td>
         <td>username:password - Enforces access for one user or /auth/file/path/and/name - Enforces access for a file of users with encrypted passwords on startup</td>
@@ -324,7 +319,6 @@ Configuration with defaults. tests, suites and a suiteFilter can be mixed. A sui
 			&lt;stopTestsOnIgnore&gt;false&lt;/stopTestsOnIgnore&gt;
 			&lt;stopTestsOnException&gt;true&lt;/stopTestsOnException&gt;
 			&lt;stopTestsOnWrong&gt;true&lt;/stopTestsOnWrong&gt;
-			&lt;unpackWaitTime&gt;3000&lt;/unpackWaitTime&gt;
 			&lt;tests&gt;
 				&lt;test&gt;FrontPage.IntegrationTest&lt;/test&gt;
 				&lt;test&gt;...&lt;/test&gt;

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Configuration:
         <td>${basedir}/log/</td>
         <td>Where to put and what to call the run log.</td>
     </tr>
+    <tr>
+        <td>connectionAttempts</td>
+        <td>4</td>
+        <td>Mafia waits for the startup of FitNesse by trying to connect to it. This configuration determines how often Mafia will attempt.</td>
+    </tr>
  </table>
 
 Configuration example with defaults and example values:
@@ -114,6 +119,7 @@ Configuration example with defaults and example values:
 				&lt;/dependency&gt;
 			&lt;/jvmDependencies&gt;
 			&lt;log>${basedir}/log/&lt;/log&gt;
+			&lt;connectionAttempts&gt4&lt;/connectionAttempts&gt;
 		&lt;/configuration&gt;
 	 &lt;/plugin&gt;
   </code>
@@ -287,6 +293,11 @@ Configuration:
         <td>false</td>
         <td>If true, every test result will be written to the folder "surefire-reports" in the maven build directory. This enabled tools like Jenkins to recognize if a test failed.</td>
     </tr>
+    <tr>
+        <td>connectionAttempts</td>
+        <td>4</td>
+        <td>Mafia waits for the startup of FitNesse by trying to connect to it. This configuration determines how often Mafia will attempt.</td>
+    </tr>
  </table>
 
 Configuration with defaults. tests, suites and a suiteFilter can be mixed. A suiteFilter needs a suitePageName.
@@ -322,6 +333,8 @@ Configuration with defaults. tests, suites and a suiteFilter can be mixed. A sui
 			&lt;/suites&gt;
 			&lt;suitePageName&gt;FrontPage.SomeSuite&lt;/suitePageName&gt;
 			&lt;suiteFilter&gt;critical_tests&lt;/suiteFilter&gt;
+			&lt;writeSurefireReports&gtfalse&lt;/writeSurefireReports&gt;
+			&lt;connectionAttempts&gt4&lt;/connectionAttempts&gt;
 		&lt;/configuration&gt;
 	&lt;/plugin&gt;
   </code>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This plugin let's you control:
 
 Supported versions of FitNesse:
 
+- 20150226
 - 20140630
 - 20140623
 - 20140418

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseMojo.java
@@ -86,13 +86,6 @@ public abstract class AbstractFitNesseMojo extends AbstractMojo {
     private String logDirectory;
 
     /**
-     * The time to wait after a fitnesse has been started.
-     */
-    @Parameter(property = "unpackWaitTime", defaultValue = "3000")
-    private long unpackWaitTime;
-
-
-    /**
      * fitNesse user:password or file
      */
     @Parameter(property = "fitNesseAuthenticateStart", defaultValue = "")
@@ -164,7 +157,7 @@ public abstract class AbstractFitNesseMojo extends AbstractMojo {
             final String classpathString = createClasspathString(jvmDependencies, jarLocator.getFitNesseJarPath());
 
             return new FitNesseCommanderConfig(port, wikiRoot, nameRootPage, logDirectory, retainDays,
-                    classpathString, jvmArguments, unpackWaitTime, getLog(),
+                    classpathString, jvmArguments, getLog(),
                     fitNesseAuthenticateStart, fitNesseAuthenticateStop, fitNesseUpdatePrevents, fitNesseVerbose);
         } catch (MafiaException e) {
             throw new MojoFailureException("Could not get command configuration.", e);

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseMojo.java
@@ -1,10 +1,14 @@
 package nl.sijpesteijn.testing.fitnesse.plugins;
 
+import java.io.File;
+import java.util.List;
+
 import nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseCommanderConfig;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.FitNesseJarLocator;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaProject;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.Project;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Dependency;
@@ -16,9 +20,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectBuilder;
 import org.apache.maven.repository.RepositorySystem;
 import org.apache.maven.settings.Settings;
-
-import java.io.File;
-import java.util.List;
 
 /**
  * AbstractFitNesseMojo.
@@ -112,18 +113,8 @@ public abstract class AbstractFitNesseMojo extends AbstractMojo {
 
 
 
-    /**
-     * Get a commander configuration.
-     *
-     * @return {@link nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseCommanderConfig}
-     * @throws MojoFailureException thrown in cause of an error.
-     */
-    protected final FitNesseCommanderConfig getCommanderConfig() throws MojoFailureException {
-        return getCommanderConfig(null, null, 0, fitNessePort, null);
-    }
-
     protected final FitNesseCommanderConfig getCommanderConfig(String fitNesseAuthenticate) throws MojoFailureException {
-        return getCommanderConfig(null, null, 0, fitNessePort, fitNesseAuthenticate);
+        return getCommanderConfig(null, null, 0, fitNessePort, fitNesseAuthenticate, 0);
     }
 
     /**
@@ -149,7 +140,8 @@ public abstract class AbstractFitNesseMojo extends AbstractMojo {
      */
     protected final FitNesseCommanderConfig getCommanderConfig(final List<Dependency> jvmDependencies,
                                                                final List<String> jvmArguments,
-                                                               final int retainDays, final int port, String fitNesseAuthenticateStart)
+                                                               final int retainDays, final int port, String fitNesseAuthenticateStart,
+                                                               int connectionAttempts)
             throws MojoFailureException {
         try {
             final FitNesseJarLocator jarLocator = new FitNesseJarLocator(getMafiaProject());
@@ -158,7 +150,7 @@ public abstract class AbstractFitNesseMojo extends AbstractMojo {
 
             return new FitNesseCommanderConfig(port, wikiRoot, nameRootPage, logDirectory, retainDays,
                     classpathString, jvmArguments, getLog(),
-                    fitNesseAuthenticateStart, fitNesseAuthenticateStop, fitNesseUpdatePrevents, fitNesseVerbose);
+                    fitNesseAuthenticateStart, fitNesseAuthenticateStop, fitNesseUpdatePrevents, fitNesseVerbose, connectionAttempts);
         } catch (MafiaException e) {
             throw new MojoFailureException("Could not get command configuration.", e);
         }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractStartFitNesseMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractStartFitNesseMojo.java
@@ -1,9 +1,9 @@
 package nl.sijpesteijn.testing.fitnesse.plugins;
 
+import java.util.List;
+
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugins.annotations.Parameter;
-
-import java.util.List;
 
 /**
  * AbstractStartFitNesseMojo.
@@ -27,6 +27,13 @@ public abstract class AbstractStartFitNesseMojo extends AbstractFitNesseMojo {
      */
     @Parameter(property = "jvmDependencies")
     private List<Dependency> jvmDependencies;
+    
+    /**
+     * Mafia waits for the startup of FitNesse by trying to connect to it. This configuration determines how often Mafia
+     * will attempt. Default: 4;
+     */
+    @Parameter(property = "connectionAttempts", defaultValue = "4")
+    private int connectionAttempts;
 
     /**
      * The number of days to preserve the test history.
@@ -53,5 +60,9 @@ public abstract class AbstractStartFitNesseMojo extends AbstractFitNesseMojo {
      */
     public final List<Dependency> getJvmDependencies() {
         return jvmDependencies;
+    }
+    
+    public int getConnectionAttempts() {
+        return connectionAttempts;
     }
 }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseRunnerMojo.java
@@ -236,7 +236,7 @@ public class FitNesseRunnerMojo extends AbstractStartFitNesseMojo {
     private void startCommander() throws MojoFailureException, MojoExecutionException {
         commander =
             new FitNesseCommander(getCommanderConfig(getJvmDependencies(), getJvmArguments(), 0,
-                fitNesseRunPort, getFitNesseAuthenticateStart()));
+                fitNesseRunPort, getFitNesseAuthenticateStart(), getConnectionAttempts()));
         try {
             commander.start();
         } catch (MafiaException me) {

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseStarterMojo.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/FitNesseStarterMojo.java
@@ -21,7 +21,7 @@ public class FitNesseStarterMojo extends AbstractStartFitNesseMojo {
         getLog().debug(toString());
         final FitNesseCommander commander = new FitNesseCommander(getCommanderConfig(getJvmDependencies(),
             getJvmArguments(),
-            getRetainDays(), getFitNessePort(), getFitNesseAuthenticateStart()));
+            getRetainDays(), getFitNessePort(), getFitNesseAuthenticateStart(), getConnectionAttempts()));
         try {
             commander.start();
         } catch (MafiaException me) {

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommander.java
@@ -148,7 +148,7 @@ public class FitNesseCommander {
         commanderConfig.getLog().debug(
             "Polling URL " + fitnesseUrl + " in order to see when Fitnesse has finished startup.");
         sleep(2000);
-        int maxTries = 4;
+        int maxTries = commanderConfig.getConnectionAttempts();
         for (int i = 1; i <= maxTries; i++) {
             try {
                 tryConnect(fitnesseUrl);

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderConfig.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderConfig.java
@@ -50,12 +50,6 @@ public class FitNesseCommanderConfig {
     private final String nameRootPage;
 
     /**
-     * Time to wait after unpacking a new fitnesse.
-     */
-    private final long unpackWaitTime;
-    
-    
-    /**
      * fitNesse authentication in start -a username:password
      *                         or filename
      */
@@ -103,7 +97,7 @@ public class FitNesseCommanderConfig {
     public FitNesseCommanderConfig(final int fitNessePort, final String wikiRoot, final String nameRootPage,
                                    final String fitNesseLogDirectory, final int retainDays,
                                    final String classpathString,
-                                   final List<String> jvmArguments, final long unpackWaitTime, final Log log, 
+                                   final List<String> jvmArguments, final Log log, 
                                    final String fitNesseAuthenticateStart,
                                    final String fitNesseAuthenticateStop,
                                    final Boolean fitNesseUpdatePrevents,
@@ -115,7 +109,6 @@ public class FitNesseCommanderConfig {
         this.retainDays = retainDays;
         this.classpathString = classpathString;
         this.jvmArguments = jvmArguments;
-        this.unpackWaitTime = unpackWaitTime;
         this.log = log;
         this.fitNesseAuthenticateStart = fitNesseAuthenticateStart;
         this.fitNesseAuthenticateStop = fitNesseAuthenticateStop;
@@ -196,10 +189,6 @@ public class FitNesseCommanderConfig {
         return classpathString;
     }
 
-    public long getUnpackWaitTime() {
-        return unpackWaitTime;
-    }
-    
     /**
      * Get the start authenticate String / File
      * @return

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderConfig.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderConfig.java
@@ -1,8 +1,8 @@
 package nl.sijpesteijn.testing.fitnesse.plugins.runner;
 
-import org.apache.maven.plugin.logging.Log;
-
 import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
 
 /**
  * FitNesse commander configuration.
@@ -70,6 +70,8 @@ public class FitNesseCommanderConfig {
      * fitNesse Verbose -o
      */
     private final Boolean fitNesseVerbose;
+    
+    private final int connectionAttempts;
 
 
 
@@ -101,7 +103,8 @@ public class FitNesseCommanderConfig {
                                    final String fitNesseAuthenticateStart,
                                    final String fitNesseAuthenticateStop,
                                    final Boolean fitNesseUpdatePrevents,
-                                   final Boolean fitNesseVerbose) {
+                                   final Boolean fitNesseVerbose,
+                                   final int connectionAttempts) {
         this.fitNessePort = fitNessePort;
         this.wikiRoot = wikiRoot;
         this.nameRootPage = nameRootPage;
@@ -114,6 +117,7 @@ public class FitNesseCommanderConfig {
         this.fitNesseAuthenticateStop = fitNesseAuthenticateStop;
         this.fitNesseUpdatePrevents = fitNesseUpdatePrevents;
         this.fitNesseVerbose = fitNesseVerbose;
+        this.connectionAttempts = connectionAttempts;
         
     }
 
@@ -212,4 +216,8 @@ public class FitNesseCommanderConfig {
 	public Boolean getFitNesseVerbose() {
 		return fitNesseVerbose;
 	}
+	
+	public int getConnectionAttempts() {
+        return connectionAttempts;
+    }
 }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
@@ -100,7 +100,7 @@ public class SurefireReportWriter {
         } else {
             String surefireReportContent = String.format(SUREFIRE_REPORT_ERROR_PART_TEMPLATE_WITH_ERROR,
                 testResult.getExitCode(),
-                testResult.getExcutionLogException(),
+                testResult.getExecutionLogException(),
                 mafiaResultsDir,
                 testResultsDir
                 );

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriter.java
@@ -34,9 +34,15 @@ public class SurefireReportWriter {
             + "</testsuite>%n";
 
     final static String SUREFIRE_REPORT_ERROR_PART_TEMPLATE =
-        "<error type=\"java.lang.AssertionError\" message=\"exceptions: %s wrong: %s\"><br/>"
-            + "See %s in workspace for more details.<br/>"
-            + "See %s for the execution log."
+        "<error type=\"java.lang.AssertionError\" message=\"exceptions: %s wrong: %s\">%n"
+            + "<br/>See %s in workspace for more details.<br/>"
+            + "See %s for the execution log.%n"
+            + "</error>";
+
+    final static String SUREFIRE_REPORT_ERROR_PART_TEMPLATE_WITH_ERROR =
+        "<error type=\"java.lang.AssertionError\" message=\"execution failed. exit code: %s, exception: %s\">%n"
+            + "<br/>See %s in workspace for more details.<br/>"
+            + "See %s for the execution log.%n"
             + "</error>";
 
     public void serialize(List<TestResult> testResults, File surefireReportBaseDir) {
@@ -79,17 +85,28 @@ public class SurefireReportWriter {
     }
 
     private String createErrorXmlPart(TestResult testResult) {
-        boolean noTestFailures = testResult.getExceptionCount() + testResult.getWrongTestCount() == 0;
-        if (noTestFailures) {
-            return "";
+        if (testResult.executedSuccessfully()) {
+            boolean noTestFailures = testResult.getExceptionCount() + testResult.getWrongTestCount() == 0;
+            if (noTestFailures) {
+                return "";
+            }
+            String surefireReportContent = String.format(SUREFIRE_REPORT_ERROR_PART_TEMPLATE,
+                testResult.getExceptionCount(),
+                testResult.getWrongTestCount(),
+                mafiaResultsDir,
+                testResultsDir
+                );
+            return surefireReportContent;
+        } else {
+            String surefireReportContent = String.format(SUREFIRE_REPORT_ERROR_PART_TEMPLATE_WITH_ERROR,
+                testResult.getExitCode(),
+                testResult.getExcutionLogException(),
+                mafiaResultsDir,
+                testResultsDir
+                );
+            return surefireReportContent;
+            
         }
-        String surefireReportContent = String.format(SUREFIRE_REPORT_ERROR_PART_TEMPLATE,
-            testResult.getExceptionCount(),
-            testResult.getWrongTestCount(),
-            mafiaResultsDir,
-            testResultsDir
-            );
-        return surefireReportContent;
     }
 
     private TestResultException fireException(File targetFile, Exception e) {

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResult.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResult.java
@@ -6,121 +6,150 @@ import org.apache.commons.lang.StringUtils;
 
 public class TestResult {
 
-	private String[] path;
-	private int rightTestCount;
-	private int wrongTestCount;
-	private int ignoredTestCount;
-	private int exceptionCount;
-	private long runTimeInMillis;
+    private String[] path;
+    private int rightTestCount;
+    private int wrongTestCount;
+    private int ignoredTestCount;
+    private int exceptionCount;
+    private long runTimeInMillis;
+    private int exitCode;
+    private String excutionLogException;
 
-	TestResult() {}
+    TestResult() {}
 
-	public TestResult withPath(String path) {
-		this.path = StringUtils.split(path, '.');
-		return this;
-	}
+    public TestResult withPath(String path) {
+        this.path = StringUtils.split(path, '.');
+        return this;
+    }
 
-	public TestResult withRightTestCount(int rightTestCount) {
-		this.rightTestCount = rightTestCount;
-		return this;
-	}
+    public TestResult withRightTestCount(int rightTestCount) {
+        this.rightTestCount = rightTestCount;
+        return this;
+    }
 
-	public TestResult withWrongTestCount(int wrongTestCount) {
-		this.wrongTestCount = wrongTestCount;
-		return this;
-	}
+    public TestResult withWrongTestCount(int wrongTestCount) {
+        this.wrongTestCount = wrongTestCount;
+        return this;
+    }
 
-	public TestResult withIgnoredTestCount(int ignoredTestCount) {
-		this.ignoredTestCount = ignoredTestCount;
-		return this;
-	}
+    public TestResult withIgnoredTestCount(int ignoredTestCount) {
+        this.ignoredTestCount = ignoredTestCount;
+        return this;
+    }
 
-	public TestResult withExceptionCount(int exceptionCount) {
-		this.exceptionCount = exceptionCount;
-		return this;
-	}
+    public TestResult withExceptionCount(int exceptionCount) {
+        this.exceptionCount = exceptionCount;
+        return this;
+    }
 
-	public TestResult withRunTimeInMillis(long runTimeInMillis) {
-		this.runTimeInMillis = runTimeInMillis;
-		return this;
-	}
+    public TestResult withRunTimeInMillis(long runTimeInMillis) {
+        this.runTimeInMillis = runTimeInMillis;
+        return this;
+    }
 
-	public String getPath() {
-		return StringUtils.join(path, ".");
-	}
+    public TestResult withExitCode(int exitCode) {
+        this.exitCode = exitCode;
+        return this;
+    }
 
-	public int getRightTestCount() {
-		return rightTestCount;
-	}
+    public TestResult withExcutionLogException(String excutionLogException) {
+        this.excutionLogException = excutionLogException;
+        return this;
+    }
 
-	public int getWrongTestCount() {
-		return wrongTestCount;
-	}
+    public String getPath() {
+        return StringUtils.join(path, ".");
+    }
 
-	public int getIgnoredTestCount() {
-		return ignoredTestCount;
-	}
+    public int getRightTestCount() {
+        return rightTestCount;
+    }
 
-	public int getExceptionCount() {
-		return exceptionCount;
-	}
+    public int getWrongTestCount() {
+        return wrongTestCount;
+    }
 
-	public long getRunTimeInMillis() {
-		return runTimeInMillis;
-	}
+    public int getIgnoredTestCount() {
+        return ignoredTestCount;
+    }
 
-	public double getRunTimeInSec() {
-		return runTimeInMillis / 1000.0;
-	}
+    public int getExceptionCount() {
+        return exceptionCount;
+    }
 
-	@Override
-	public String toString() {
-		return "TestResult [path=" + path + ", rightTestCount=" + rightTestCount + ", wrongTestCount="
-			+ wrongTestCount + ", ignoredTestCount=" + ignoredTestCount + ", exceptionCount=" + exceptionCount
-			+ ", runTimeInMillis=" + runTimeInMillis + "]";
-	}
+    public long getRunTimeInMillis() {
+        return runTimeInMillis;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + exceptionCount;
-		result = prime * result + ignoredTestCount;
-		result = prime * result + ((path == null) ? 0 : path.hashCode());
-		result = prime * result + rightTestCount;
-		result = prime * result + (int) (runTimeInMillis ^ (runTimeInMillis >>> 32));
-		result = prime * result + wrongTestCount;
-		return result;
-	}
+    public double getRunTimeInSec() {
+        return runTimeInMillis / 1000.0;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) return true;
-		if (obj == null) return false;
-		if (getClass() != obj.getClass()) return false;
-		TestResult other = (TestResult) obj;
-		if (exceptionCount != other.exceptionCount) return false;
-		if (ignoredTestCount != other.ignoredTestCount) return false;
-		if (path == null) {
-			if (other.path != null) return false;
-		} else if (!Arrays.equals(path, other.path)) return false;
-		if (rightTestCount != other.rightTestCount) return false;
-		if (runTimeInMillis != other.runTimeInMillis) return false;
-		if (wrongTestCount != other.wrongTestCount) return false;
-		return true;
-	}
+    public int getExitCode() {
+        return exitCode;
+    }
 
-	public Object getTotalTestCount() {
-		return rightTestCount + wrongTestCount + exceptionCount + ignoredTestCount;
-	}
+    public boolean executedSuccessfully() {
+        return exitCode == 0;
+    }
 
-	public Object getSuiteName() {
-		String[] pathWithoutTest = Arrays.copyOf(path, path.length - 1);
-		return StringUtils.join(pathWithoutTest, ".");
-	}
+    public String getExcutionLogException() {
+        return excutionLogException;
+    }
 
-	public Object getTestName() {
-		return path[path.length - 1];
-	}
+    public Object getTotalTestCount() {
+        return rightTestCount + wrongTestCount + exceptionCount + ignoredTestCount;
+    }
+
+    public Object getSuiteName() {
+        String[] pathWithoutTest = Arrays.copyOf(path, path.length - 1);
+        return StringUtils.join(pathWithoutTest, ".");
+    }
+
+    public Object getTestName() {
+        return path[path.length - 1];
+    }
+
+    @Override
+    public String toString() {
+        return "TestResult [path=" + Arrays.toString(path) + ", rightTestCount=" + rightTestCount + ", wrongTestCount="
+            + wrongTestCount + ", ignoredTestCount=" + ignoredTestCount + ", exceptionCount=" + exceptionCount
+            + ", runTimeInMillis=" + runTimeInMillis + ", exitCode=" + exitCode + ", excutionLogException=" + excutionLogException
+            + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + exceptionCount;
+        result = prime * result + ((excutionLogException == null) ? 0 : excutionLogException.hashCode());
+        result = prime * result + exitCode;
+        result = prime * result + ignoredTestCount;
+        result = prime * result + Arrays.hashCode(path);
+        result = prime * result + rightTestCount;
+        result = prime * result + (int) (runTimeInMillis ^ (runTimeInMillis >>> 32));
+        result = prime * result + wrongTestCount;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        TestResult other = (TestResult) obj;
+        if (exceptionCount != other.exceptionCount) return false;
+        if (excutionLogException == null) {
+            if (other.excutionLogException != null) return false;
+        } else if (!excutionLogException.equals(other.excutionLogException)) return false;
+        if (exitCode != other.exitCode) return false;
+        if (ignoredTestCount != other.ignoredTestCount) return false;
+        if (!Arrays.equals(path, other.path)) return false;
+        if (rightTestCount != other.rightTestCount) return false;
+        if (runTimeInMillis != other.runTimeInMillis) return false;
+        if (wrongTestCount != other.wrongTestCount) return false;
+        return true;
+    }
 
 }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResult.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResult.java
@@ -12,8 +12,8 @@ public class TestResult {
     private int ignoredTestCount;
     private int exceptionCount;
     private long runTimeInMillis;
-    private int exitCode;
-    private String excutionLogException;
+    private Integer exitCode;
+    private String executionLogException;
 
     TestResult() {}
 
@@ -47,13 +47,13 @@ public class TestResult {
         return this;
     }
 
-    public TestResult withExitCode(int exitCode) {
+    public TestResult withExitCode(Integer exitCode) {
         this.exitCode = exitCode;
         return this;
     }
 
-    public TestResult withExcutionLogException(String excutionLogException) {
-        this.excutionLogException = excutionLogException;
+    public TestResult withExecutionLogException(String executionLogException) {
+        this.executionLogException = executionLogException;
         return this;
     }
 
@@ -85,16 +85,19 @@ public class TestResult {
         return runTimeInMillis / 1000.0;
     }
 
-    public int getExitCode() {
+    public Integer getExitCode() {
         return exitCode;
     }
 
     public boolean executedSuccessfully() {
+        if (exitCode == null){
+            return true;
+        }
         return exitCode == 0;
     }
 
-    public String getExcutionLogException() {
-        return excutionLogException;
+    public String getExecutionLogException() {
+        return executionLogException;
     }
 
     public Object getTotalTestCount() {
@@ -114,7 +117,7 @@ public class TestResult {
     public String toString() {
         return "TestResult [path=" + Arrays.toString(path) + ", rightTestCount=" + rightTestCount + ", wrongTestCount="
             + wrongTestCount + ", ignoredTestCount=" + ignoredTestCount + ", exceptionCount=" + exceptionCount
-            + ", runTimeInMillis=" + runTimeInMillis + ", exitCode=" + exitCode + ", excutionLogException=" + excutionLogException
+            + ", runTimeInMillis=" + runTimeInMillis + ", exitCode=" + exitCode + ", excutionLogException=" + executionLogException
             + "]";
     }
 
@@ -123,8 +126,8 @@ public class TestResult {
         final int prime = 31;
         int result = 1;
         result = prime * result + exceptionCount;
-        result = prime * result + ((excutionLogException == null) ? 0 : excutionLogException.hashCode());
-        result = prime * result + exitCode;
+        result = prime * result + ((executionLogException == null) ? 0 : executionLogException.hashCode());
+        result = prime * result + ((exitCode == null) ? 0 : exitCode.hashCode());
         result = prime * result + ignoredTestCount;
         result = prime * result + Arrays.hashCode(path);
         result = prime * result + rightTestCount;
@@ -140,10 +143,12 @@ public class TestResult {
         if (getClass() != obj.getClass()) return false;
         TestResult other = (TestResult) obj;
         if (exceptionCount != other.exceptionCount) return false;
-        if (excutionLogException == null) {
-            if (other.excutionLogException != null) return false;
-        } else if (!excutionLogException.equals(other.excutionLogException)) return false;
-        if (exitCode != other.exitCode) return false;
+        if (executionLogException == null) {
+            if (other.executionLogException != null) return false;
+        } else if (!executionLogException.equals(other.executionLogException)) return false;
+        if (exitCode == null) {
+            if (other.exitCode != null) return false;
+        } else if (!exitCode.equals(other.exitCode)) return false;
         if (ignoredTestCount != other.ignoredTestCount) return false;
         if (!Arrays.equals(path, other.path)) return false;
         if (rightTestCount != other.rightTestCount) return false;
@@ -151,5 +156,7 @@ public class TestResult {
         if (wrongTestCount != other.wrongTestCount) return false;
         return true;
     }
+
+    
 
 }

--- a/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
+++ b/src/main/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReader.java
@@ -10,14 +10,12 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
 
 import org.apache.maven.plugin.logging.Log;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 /**
@@ -77,34 +75,15 @@ public class TestResultReader {
             if (!rootElement.getNodeName().equals("testResults")) {
                 return null;
             }
-            XPath xpath = XPathFactory.newInstance().newXPath();
+            TestResult testResult = createBeanWithBaseInfo(rootElement);
 
-            String path = rootElement.getElementsByTagName("rootPath").item(0).getTextContent();
-            String runTimeString = rootElement.getElementsByTagName("totalRunTimeInMillis").item(0).getTextContent();
             Element executionLogNode = (Element) rootElement.getElementsByTagName("executionLog").item(0);
-            String exitCode = executionLogNode.getElementsByTagName("exitCode").item(0).getTextContent();
-            
-            TestResult testResult = new TestResult()
-                .withPath(path)
-                .withExitCode(Integer.parseInt(exitCode))
-                .withRunTimeInMillis(Long.parseLong(runTimeString));
-
-            boolean isNormalExecution = exitCode.equals("0");
-            if (isNormalExecution) {
-                Element countsNode = (Element) xpath.evaluate("result/counts", rootElement, XPathConstants.NODE);
-                String rightCount = countsNode.getElementsByTagName("right").item(0).getTextContent();
-                String wrongCount = countsNode.getElementsByTagName("wrong").item(0).getTextContent();
-                String ignoresCount = countsNode.getElementsByTagName("ignores").item(0).getTextContent();
-                String exceptionsCount = countsNode.getElementsByTagName("exceptions").item(0).getTextContent();
-
-                testResult.withRightTestCount(Integer.parseInt(rightCount))
-                    .withWrongTestCount(Integer.parseInt(wrongCount))
-                    .withIgnoredTestCount(Integer.parseInt(ignoresCount))
-                    .withExceptionCount(Integer.parseInt(exceptionsCount));
-            } else {//e.g. 143
-                String exceptionText = executionLogNode.getElementsByTagName("exception").item(0).getTextContent();
-                testResult.withExcutionLogException(exceptionText)
-                    .withExceptionCount(1);
+            if (executionLogNode != null) {
+                fillBeanWithExecutionLogInfo(testResult, executionLogNode);
+            }
+            Element resultNode = (Element) rootElement.getElementsByTagName("result").item(0);
+            if (resultNode != null) {
+                fillBeanWithResults(testResult, resultNode);
             }
             return testResult;
         } catch (ParserConfigurationException e) {
@@ -118,7 +97,43 @@ public class TestResultReader {
         }
     }
 
-    private Element getRootXmlElement(File testResultFile) throws ParserConfigurationException, SAXException, IOException {
+    private TestResult createBeanWithBaseInfo(Element rootElement) {
+        String path = rootElement.getElementsByTagName("rootPath").item(0).getTextContent();
+        String runTimeString = rootElement.getElementsByTagName("totalRunTimeInMillis").item(0).getTextContent();
+        TestResult testResult = new TestResult()
+            .withPath(path)
+            .withRunTimeInMillis(Long.parseLong(runTimeString));
+        return testResult;
+    }
+
+    private void fillBeanWithExecutionLogInfo(TestResult testResult, Element executionLogNode) {
+        String exitCode = executionLogNode.getElementsByTagName("exitCode").item(0).getTextContent();
+        testResult.withExitCode(Integer.parseInt(exitCode));
+        Node exceptionNode = executionLogNode.getElementsByTagName("exception").item(0);
+        if (exceptionNode != null) {
+            String exceptionText = exceptionNode.getTextContent();
+            if (!exceptionText.trim().isEmpty()) {
+                testResult.withExecutionLogException(exceptionText)
+                    .withExceptionCount(1);
+            }
+        }
+    }
+
+    private void fillBeanWithResults(TestResult testResult, Element resultNode) throws XPathExpressionException {
+        Element countsNode = (Element) resultNode.getElementsByTagName("counts").item(0);
+        String rightCount = countsNode.getElementsByTagName("right").item(0).getTextContent();
+        String wrongCount = countsNode.getElementsByTagName("wrong").item(0).getTextContent();
+        String ignoresCount = countsNode.getElementsByTagName("ignores").item(0).getTextContent();
+        String exceptionsCount = countsNode.getElementsByTagName("exceptions").item(0).getTextContent();
+
+        testResult.withRightTestCount(Integer.parseInt(rightCount))
+            .withWrongTestCount(Integer.parseInt(wrongCount))
+            .withIgnoredTestCount(Integer.parseInt(ignoresCount))
+            .withExceptionCount(Integer.parseInt(exceptionsCount));
+    }
+
+    private Element getRootXmlElement(File testResultFile) throws ParserConfigurationException, SAXException,
+        IOException {
         DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document document = builder.parse(testResultFile);
         Element rootElement = document.getDocumentElement();

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseTest.java
@@ -1,11 +1,11 @@
 package nl.sijpesteijn.testing.fitnesse.plugins;
 
-import nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseCommanderConfig;
-import nl.sijpesteijn.testing.fitnesse.plugins.stub.LoggerStub;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
+import nl.sijpesteijn.testing.fitnesse.plugins.runner.FitNesseCommanderConfig;
+import nl.sijpesteijn.testing.fitnesse.plugins.stub.LoggerStub;
 
 /**
  * User: gijs
@@ -25,6 +25,6 @@ public class AbstractFitNesseTest {
 
     public static FitNesseCommanderConfig getFitnesseCommanderConfig() {
         return new FitNesseCommanderConfig(PORT, WIKI_ROOT, NAME_ROOT_PAGE, LOG_DIRECTORY,0,
-                FITNESSE_JAR_PATH, jvmArguments ,mockLog, null, null, null, null);
+                FITNESSE_JAR_PATH, jvmArguments ,mockLog, null, null, null, null, 4);
     }
 }

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/AbstractFitNesseTest.java
@@ -25,6 +25,6 @@ public class AbstractFitNesseTest {
 
     public static FitNesseCommanderConfig getFitnesseCommanderConfig() {
         return new FitNesseCommanderConfig(PORT, WIKI_ROOT, NAME_ROOT_PAGE, LOG_DIRECTORY,0,
-                FITNESSE_JAR_PATH, jvmArguments, 3000 ,mockLog, null, null, null, null);
+                FITNESSE_JAR_PATH, jvmArguments ,mockLog, null, null, null, null);
     }
 }

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderTest.java
@@ -43,7 +43,7 @@ public class FitNesseCommanderTest extends AbstractFitNesseTest {
 
             FitNesseCommanderConfig config = new FitNesseCommanderConfig(PORT, WIKI_ROOT, NAME_ROOT_PAGE,
                     LOG_DIRECTORY, 0, FITNESSE_JAR_PATH,
-                    null, 3000, mockLog, null, null, null, null);
+                    null, mockLog, null, null, null, null);
             commander = new FitNesseCommander(config);
             commander.start();
             assertFalse(commander.hasError());
@@ -60,7 +60,7 @@ public class FitNesseCommanderTest extends AbstractFitNesseTest {
     public void failureWikiRoot() throws Exception {
         FitNesseCommanderConfig config = new FitNesseCommanderConfig(PORT, "$&#&^&$", NAME_ROOT_PAGE,
                 null, 0, FITNESSE_JAR_PATH,
-                null, 3000, mockLog, null, null, null, null);
+                null, mockLog, null, null, null, null);
         commander = new FitNesseCommander(config);
         commander.start();
     }

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/runner/FitNesseCommanderTest.java
@@ -1,13 +1,11 @@
 package nl.sijpesteijn.testing.fitnesse.plugins.runner;
 
+import static junit.framework.Assert.*;
 import nl.sijpesteijn.testing.fitnesse.plugins.AbstractFitNesseTest;
 import nl.sijpesteijn.testing.fitnesse.plugins.utils.MafiaException;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import static junit.framework.Assert.assertNotNull;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * User: gijs
@@ -43,7 +41,7 @@ public class FitNesseCommanderTest extends AbstractFitNesseTest {
 
             FitNesseCommanderConfig config = new FitNesseCommanderConfig(PORT, WIKI_ROOT, NAME_ROOT_PAGE,
                     LOG_DIRECTORY, 0, FITNESSE_JAR_PATH,
-                    null, mockLog, null, null, null, null);
+                    null, mockLog, null, null, null, null, 4);
             commander = new FitNesseCommander(config);
             commander.start();
             assertFalse(commander.hasError());
@@ -60,7 +58,7 @@ public class FitNesseCommanderTest extends AbstractFitNesseTest {
     public void failureWikiRoot() throws Exception {
         FitNesseCommanderConfig config = new FitNesseCommanderConfig(PORT, "$&#&^&$", NAME_ROOT_PAGE,
                 null, 0, FITNESSE_JAR_PATH,
-                null, mockLog, null, null, null, null);
+                null, mockLog, null, null, null, null, 4);
         commander = new FitNesseCommander(config);
         commander.start();
     }

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriterTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/SurefireReportWriterTest.java
@@ -61,13 +61,35 @@ public class SurefireReportWriterTest {
         .withExceptionCount(1)
         .withRunTimeInMillis(300)
         .withExitCode(143)
-        .withExcutionLogException("Read timed out");
+        .withExecutionLogException("Read timed out");
         
         File serializedReport = new File(serializedReportFolder, "report2-exception.xml");
         surefireReportWriter.serialize(expectedTestResult, serializedReport);
         
         List<String> serializedReportContent = IOUtils.readLines(new FileReader(serializedReport));
         File expectedReport = new File(EXPRECTED_SUREFIRE_REPORTS_DIR, "report2-exception.xml");
+        List<String> expectedReportContent = IOUtils.readLines(new FileReader(expectedReport));
+        
+        assertListEquals(serializedReportContent, expectedReportContent);
+    }
+    
+    @Test
+    public void serializeSingleFileWithoutExecutionLog() throws FileNotFoundException, IOException {
+        TestResult expectedTestResult = new TestResult()
+        .withPath("Suite1.Suite11.Test1")
+        .withRightTestCount(1)
+        .withWrongTestCount(0)
+        .withIgnoredTestCount(0)
+        .withExceptionCount(0)
+        .withRunTimeInMillis(300)
+        .withExitCode(null)
+        .withExecutionLogException(null);
+        
+        File serializedReport = new File(serializedReportFolder, "report3-noExecLog.xml");
+        surefireReportWriter.serialize(expectedTestResult, serializedReport);
+        
+        List<String> serializedReportContent = IOUtils.readLines(new FileReader(serializedReport));
+        File expectedReport = new File(EXPRECTED_SUREFIRE_REPORTS_DIR, "report3-noExecLog.xml");
         List<String> expectedReportContent = IOUtils.readLines(new FileReader(expectedReport));
         
         assertListEquals(serializedReportContent, expectedReportContent);

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReaderTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReaderTest.java
@@ -34,13 +34,16 @@ public class TestResultReaderTest {
 			.withWrongTestCount(46)
 			.withIgnoredTestCount(10)
 			.withExceptionCount(1)
-			.withRunTimeInMillis(903);
+			.withRunTimeInMillis(903)
+			.withExitCode(0)
+			.withExecutionLogException(null);
 
 		File file = new File(TEST_RESULT_BASE_FOLDER + "/Test1/20150408111924_0_1_0_0.xml");
 		TestResult testResult = testResultReader.readTestResultFile(file);
 		assertTrue(testResult.executedSuccessfully());
 		assertEquals(expectedTestResult, testResult);
 	}
+
 
 	/**
 	 * don't use suites and only use latest xml file in a folder.
@@ -49,7 +52,7 @@ public class TestResultReaderTest {
 	public void readAllTestResultFiles() {
 		File baseFolder = new File(TEST_RESULT_BASE_FOLDER);
 		List<TestResult> testResults = testResultReader.readAllTestResultFiles(baseFolder);
-		assertEquals(5, testResults.size());
+		assertEquals(6, testResults.size());
 	}
 	
 	@Test
@@ -58,9 +61,23 @@ public class TestResultReaderTest {
 	    TestResult testResult = testResultReader.readTestResultFile(file);
 	    assertFalse(testResult.executedSuccessfully());
 	    assertEquals(1, testResult.getExceptionCount());
-	    assertEquals(143, testResult.getExitCode());
-	    assertEquals("Read timed out", testResult.getExcutionLogException());
+	    assertEquals(143, (int)testResult.getExitCode());
+	    assertEquals("Read timed out", testResult.getExecutionLogException());
 	}
 	
+	   
+    @Test
+     public void fileWithoutExecutionLog() {
+        File file = new File(TEST_RESULT_BASE_FOLDER + "/Test6-noExecLog/20150428121832_1_0_0_0.xml");
+        TestResult testResult = testResultReader.readTestResultFile(file);
+        assertTrue(testResult.executedSuccessfully());
+        assertEquals(3, testResult.getRightTestCount());
+        assertEquals(0, testResult.getWrongTestCount());
+        assertEquals(0, testResult.getIgnoredTestCount());
+        assertEquals(0, testResult.getExceptionCount());
+        assertEquals(625, testResult.getRunTimeInMillis());
+        assertEquals(null, testResult.getExitCode());
+        assertEquals(null, testResult.getExecutionLogException());
+    }
 
 }

--- a/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReaderTest.java
+++ b/src/test/java/nl/sijpesteijn/testing/fitnesse/plugins/utils/surefirereport/TestResultReaderTest.java
@@ -5,9 +5,6 @@ import static junit.framework.Assert.*;
 import java.io.File;
 import java.util.List;
 
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.TestResult;
-import nl.sijpesteijn.testing.fitnesse.plugins.utils.surefirereport.TestResultReader;
-
 import org.apache.maven.plugin.testing.SilentLog;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,6 +38,7 @@ public class TestResultReaderTest {
 
 		File file = new File(TEST_RESULT_BASE_FOLDER + "/Test1/20150408111924_0_1_0_0.xml");
 		TestResult testResult = testResultReader.readTestResultFile(file);
+		assertTrue(testResult.executedSuccessfully());
 		assertEquals(expectedTestResult, testResult);
 	}
 
@@ -51,7 +49,18 @@ public class TestResultReaderTest {
 	public void readAllTestResultFiles() {
 		File baseFolder = new File(TEST_RESULT_BASE_FOLDER);
 		List<TestResult> testResults = testResultReader.readAllTestResultFiles(baseFolder);
-		assertEquals(4, testResults.size());
+		assertEquals(5, testResults.size());
 	}
+	
+	@Test
+	public void fileWithException(){
+	    File file = new File(TEST_RESULT_BASE_FOLDER + "/Test5-exception/20150423141746_0_0_0_0.xml");
+	    TestResult testResult = testResultReader.readTestResultFile(file);
+	    assertFalse(testResult.executedSuccessfully());
+	    assertEquals(1, testResult.getExceptionCount());
+	    assertEquals(143, testResult.getExitCode());
+	    assertEquals("Read timed out", testResult.getExcutionLogException());
+	}
+	
 
 }

--- a/src/test/resources/expected-surefire-reports/report2-exception.xml
+++ b/src/test/resources/expected-surefire-reports/report2-exception.xml
@@ -1,7 +1,7 @@
-<testsuite errors="1" skipped="1" tests="11" time="0.3" failures="4" name="Suite1.Suite11">
+<testsuite errors="1" skipped="0" tests="1" time="0.3" failures="0" name="Suite1.Suite11">
 <properties/>
 <testcase classname="Suite1.Suite11.Test1" time="0.3" name="Test1">
-<error type="java.lang.AssertionError" message="exceptions: 1 wrong: 4">
+<error type="java.lang.AssertionError" message="execution failed. exit code: 143, exception: Read timed out">
 <br/>See dummypath/ in workspace for more details.<br/>See dummypath2/ for the execution log.
 </error>
 </testcase>

--- a/src/test/resources/expected-surefire-reports/report3-noExecLog.xml
+++ b/src/test/resources/expected-surefire-reports/report3-noExecLog.xml
@@ -1,0 +1,6 @@
+<testsuite errors="0" skipped="0" tests="1" time="0.3" failures="0" name="Suite1.Suite11">
+<properties/>
+<testcase classname="Suite1.Suite11.Test1" time="0.3" name="Test1">
+
+</testcase>
+</testsuite>

--- a/src/test/resources/testResults/Suite1/20150401112919_1_0_0_0.xml
+++ b/src/test/resources/testResults/Suite1/20150401112919_1_0_0_0.xml
@@ -15,6 +15,13 @@
 		</counts>
 		<runTimeInMillis>9541</runTimeInMillis>
 	</pageHistoryReference>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>1</right>
 		<wrong>0</wrong>

--- a/src/test/resources/testResults/Test1/20150408111924_0_1_0_0.xml
+++ b/src/test/resources/testResults/Test1/20150408111924_0_1_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>903</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>0</right>
 		<wrong>1</wrong>

--- a/src/test/resources/testResults/Test2/20150408111925_0_1_0_0.xml
+++ b/src/test/resources/testResults/Test2/20150408111925_0_1_0_0.xml
@@ -12,6 +12,13 @@
 		<runTimeInMillis>942</runTimeInMillis>
 		<content></content>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>0</right>
 		<wrong>1</wrong>

--- a/src/test/resources/testResults/Test3/20150408111943_0_1_0_0.xml
+++ b/src/test/resources/testResults/Test3/20150408111943_0_1_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>760</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>0</right>
 		<wrong>1</wrong>

--- a/src/test/resources/testResults/Test5-exception/20150423141746_0_0_0_0.xml
+++ b/src/test/resources/testResults/Test5-exception/20150423141746_0_0_0_0.xml
@@ -1,29 +1,21 @@
 <?xml version="1.0"?>
 <testResults>
 	<FitNesseVersion>v20150226</FitNesseVersion>
-	<rootPath>Tests4-Many</rootPath>
-	<result>
-		<counts>
-			<right>1</right>
-			<wrong>7</wrong>
-			<ignores>4</ignores>
-			<exceptions>3</exceptions>
-		</counts>
-		<runTimeInMillis>733</runTimeInMillis>
-	</result>
+	<rootPath>TestWithException</rootPath>
 	<executionLog>
 		<testSystem></testSystem>
 		<command></command>
-		<exitCode>0</exitCode>
+		<exitCode>143</exitCode>
 		<stdOut></stdOut>
 		<stdErr></stdErr>
+		<exception>Read timed out</exception>
 	</executionLog>
 	<finalCounts>
 		<right>0</right>
-		<wrong>1</wrong>
+		<wrong>0</wrong>
 		<ignores>0</ignores>
 		<exceptions>0</exceptions>
 	</finalCounts>
-	<totalRunTimeInMillis>733</totalRunTimeInMillis>
+	<totalRunTimeInMillis>10270</totalRunTimeInMillis>
 </testResults>
 

--- a/src/test/resources/testResults/Test6-noExecLog/20150428121832_1_0_0_0.xml
+++ b/src/test/resources/testResults/Test6-noExecLog/20150428121832_1_0_0_0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<testResults>
+	<FitNesseVersion>v20150226</FitNesseVersion>
+	<rootPath>TestWithoutExecutionLog</rootPath>
+	<result>
+		<counts>
+			<right>3</right>
+			<wrong>0</wrong>
+			<ignores>0</ignores>
+			<exceptions>0</exceptions>
+		</counts>
+		<runTimeInMillis>625</runTimeInMillis>
+		<content>asdf</content>
+		<relativePageName>TestWithoutExecutionLog</relativePageName>
+		<instructions>
+			<!-- ... -->
+		</instructions>
+	</result>
+	<finalCounts>
+		<right>1</right>
+		<wrong>0</wrong>
+		<ignores>0</ignores>
+		<exceptions>0</exceptions>
+	</finalCounts>
+	<totalRunTimeInMillis>625</totalRunTimeInMillis>
+</testResults>
+

--- a/src/test/resources/testResults/Tests4-Many/20150401121655_1_0_0_0.xml
+++ b/src/test/resources/testResults/Tests4-Many/20150401121655_1_0_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>1032</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>1</right>
 		<wrong>0</wrong>

--- a/src/test/resources/testResults/Tests4-Many/20150407085018_1_0_0_0.xml
+++ b/src/test/resources/testResults/Tests4-Many/20150407085018_1_0_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>999</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>1</right>
 		<wrong>0</wrong>

--- a/src/test/resources/testResults/Tests4-Many/20150407140611_1_0_0_0.xml
+++ b/src/test/resources/testResults/Tests4-Many/20150407140611_1_0_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>1144</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>1</right>
 		<wrong>0</wrong>

--- a/src/test/resources/testResults/Tests4-Many/20150408134843_0_1_0_0.xml
+++ b/src/test/resources/testResults/Tests4-Many/20150408134843_0_1_0_0.xml
@@ -11,6 +11,13 @@
 		</counts>
 		<runTimeInMillis>726</runTimeInMillis>
 	</result>
+	<executionLog>
+		<testSystem></testSystem>
+		<command></command>
+		<exitCode>0</exitCode>
+		<stdOut></stdOut>
+		<stdErr></stdErr>
+	</executionLog>
 	<finalCounts>
 		<right>0</right>
 		<wrong>1</wrong>


### PR DESCRIPTION
Hi Gijs,

I like to contribute the following changes:
- Added FitNesseVersion 20150226 and the cutting edge 20150424 to the list of supported versions. In our project we used both in conjunction with mafia and everything works fine.
- There are cases where the test result xml doesn't contain an \<exectionLog\> node (e.g. if there are no decision tables in a fitnesse test). This case is taken into account now.
- I removed the unpackWaitTime configuration, because it is no longer used.
- Instead I introduced the configuration connectionAttempts. This defines how often Mafia will try to connect to FitNesse (to determine if the startup has finished) before giving up.
- Improved writeSurefireReports functionality: If a test execution fails (e.g. with a "Read timed out" which happens often with 20150226, but was fixed in 20150424), a surefire report is created signaling this error. Otherwise Jenkins thinks everything worked out fine.

I guess we are close to a release. Just give me some more days be sure, that everything works fine and stable. I will contact you, when I consider my enhancements to be good enough for a release. Are you OK about this approach? :-)

Best Regards,
Philipp